### PR TITLE
Update webpack for compatibility with `ts` imports

### DIFF
--- a/template/webpack.skpm.config.js
+++ b/template/webpack.skpm.config.js
@@ -4,4 +4,5 @@ module.exports = function (config, isPluginCommand) {
     exclude: /node_modules/,
     loader: 'ts-loader'
   });
+  config.resolve.extensions.push(".ts");
 }


### PR DESCRIPTION
When importing typescript modules from other files, you'll get errors in the compiler unless you configure webpack to resolve the ts extension.

This enables shorter imports like `import { applyToSelection, getSetting } from "./utils";`

