### PR TITLE
Extended webpack configuration for minifying TypeScript output

### DIFF
--- a/template/webpack.skpm.config.js
+++ b/template/webpack.skpm.config.js
@@ -1,13 +1,36 @@
+const webpack = require("webpack");
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+
 module.exports = function (config, isPluginCommand) {
   config.module.rules.push({
     test: /\.tsx?$/,
     exclude: /node_modules/,
     loader: 'ts-loader'
   });
+  
   if (!config.resolve) {
     config.resolve = {
       extensions: []
     };
   }
+  
   config.resolve.extensions = [...config.resolve.extensions, ".ts", ".tsx"];
+  
+  // transformations for production (publish)
+  if (isProduction) {
+    config.mode = "production";
+    config.plugins.push(
+      new webpack.LoaderOptionsPlugin({
+        minimize: true
+      }),
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          output: {
+            comments: false
+          }
+        },
+        test: /\.j|ts($|\?)/i
+      })
+    );
+  }
 }


### PR DESCRIPTION
Because skpm will only minify .js files by default, explicit config for .ts minification is required.